### PR TITLE
Bump the version.

### DIFF
--- a/Box/Info.plist
+++ b/Box/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Bumps the version to 1.0.1, since we’ll need to re-tag now that we have a shared scheme.
