### PR TITLE
Use a non-deadlocking example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ mutableBox.value = 2
 Building a recursive value type:
 
 ```swift
-struct BinaryTree<T> {
-	let value: T
-	let left: Box<BinaryTree<T>>?
-	let right: Box<BinaryTree<T>>?
+struct BinaryTree {
+	let value: Int
+	let left: Box<BinaryTree>?
+	let right: Box<BinaryTree>?
 }
 ```
 


### PR DESCRIPTION
Swift [deadlocks when you initialize `BinaryTree<T>`](http://www.openradar.me/19320857), which is not, you know, ideal.

Fixes #12.

/cc @regexident
