### PR TITLE
Mark frameworks as safe for app extensions

### DIFF
--- a/Box.xcodeproj/project.pbxproj
+++ b/Box.xcodeproj/project.pbxproj
@@ -462,6 +462,7 @@
 		D470AC4E19E86128003DA6C6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -481,6 +482,7 @@
 		D470AC4F19E86128003DA6C6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -531,6 +533,7 @@
 		F8BB81E71A939B67001AA352 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -554,6 +557,7 @@
 		F8BB81E81A939B67001AA352 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Given that we're not using anything that can't be used in an app
extension, it really makes sense to restrict ourselves to APIs that can
be used in app extensions. This won't restrict usage for applications,
but will open up the ability to use Box (and anything that depends on
Box) inside extensions.