### PR TITLE
Mark mapping closures `@noescape`

### DIFF
--- a/Box/Box.swift
+++ b/Box/Box.swift
@@ -20,7 +20,7 @@ public final class Box<T>: BoxType, Printable {
 	public let value: T
 
 	/// Constructs a new Box by transforming `value` by `f`.
-	public func map<U>(f: T -> U) -> Box<U> {
+	public func map<U>(@noescape f: T -> U) -> Box<U> {
 		return Box<U>(f(value))
 	}
 

--- a/Box/BoxType.swift
+++ b/Box/BoxType.swift
@@ -41,6 +41,6 @@ public func != <B: BoxType where B.Value: Equatable> (lhs: B, rhs: B) -> Bool {
 // MARK: Map
 
 /// Maps the value of a box into a new box.
-public func map<B: BoxType, C: BoxType>(v: B, f: B.Value -> C.Value) -> C {
+public func map<B: BoxType, C: BoxType>(v: B, @noescape f: B.Value -> C.Value) -> C {
 	return C(f(v.value))
 }

--- a/Box/Info.plist
+++ b/Box/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Box/MutableBox.swift
+++ b/Box/MutableBox.swift
@@ -15,7 +15,7 @@ public final class MutableBox<T>: MutableBoxType, Printable {
 	public var value: T
 
 	/// Constructs a new MutableBox by transforming `value` by `f`.
-	public func map<U>(f: T -> U) -> MutableBox<U> {
+	public func map<U>(@noescape f: T -> U) -> MutableBox<U> {
 		return MutableBox<U>(f(value))
 	}
 


### PR DESCRIPTION
A lot of functions in the swift standard library have this attribute as well.