### PR TITLE
Restrict Mac framework to x86_64

### DIFF
--- a/Box.xcodeproj/project.pbxproj
+++ b/Box.xcodeproj/project.pbxproj
@@ -476,6 +476,7 @@
 				PRODUCT_NAME = Box;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -495,6 +496,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = Box;
 				SKIP_INSTALL = YES;
+				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
I think this is a real workaround for issues like antitypical/Result#21 and antitypical/Result#25.

I don’t think this will work around issues like #21.